### PR TITLE
add(tools): gh-stats to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ It acts as an actively maintained alternative to older lists like [abhisheknaiid
 ## Tools
 
 - [Badges](https://shields.io/) - Customizable badges and labels for GitHub profiles and project READMEs.
+- [gh-stats](https://gh-stats.com/) - Dynamically generated profile stats cards and widgets for your README.
 - [GitHub profile readme generator](https://gprm.itsvg.in/) - Generates a GitHub profile README.
 - [GitHub profile readme generator](https://rahuldkjain.github.io/gh-profile-readme-generator/) - Generates a profile README in minutes.
 - [GitHub readme generator](https://readme.so/) - Simple editor to customize sections for your README.


### PR DESCRIPTION
Adds [gh-stats](https://gh-stats.com/) to the Tools section.

It generates profile stats cards and widgets (languages, streak, grade, collaborators) as SVGs you embed in a README, alongside the other dynamic-stats tools already listed.

- Open source, MIT licensed: https://github.com/ShayManor/github-readme-stats
- Live: https://gh-stats.com/

Placed in alphabetical order between `Badges` and `GitHub profile readme generator`, following the existing `- [Name](url) - Description.` format. Single-line diff.